### PR TITLE
fix: fixed IDE misinformation when configuration item is empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ const defaultOptions = {
   prefix: 'El',
 }
 
-export default (options: VitePluginElementPlusOptions) => {
+export default (options?: VitePluginElementPlusOptions) => {
   const exclude = 'node_modules/**'
   const include = ['**/*.vue', '**/*.ts', '**/*.js', '**/*.tsx', '**/*.jsx']
 


### PR DESCRIPTION
![5cbdef6d28a7e307e49a57cfbcd0b0b](https://user-images.githubusercontent.com/24516169/131237699-6fa0a02d-8212-4790-965a-bda1ea5ece9c.png)

↓ ↓ ↓ ↓ ↓ ↓

![image](https://user-images.githubusercontent.com/24516169/131237731-9d5cd405-f17d-4f7a-a0b7-c4eac83db60a.png)
